### PR TITLE
AbstractOperationCallStubs fields bug

### DIFF
--- a/src/main/java/com/hotels/plunger/AbstractOperationCallStub.java
+++ b/src/main/java/com/hotels/plunger/AbstractOperationCallStub.java
@@ -29,14 +29,15 @@ import cascading.tuple.TupleEntryCollector;
 abstract class AbstractOperationCallStub<C> implements OperationCall<C> {
 
   private C context;
-  final Fields fields;
+  private final Fields argumentFields;
+  private final Fields declaredFields;
 
   final List<TupleEntry> collected = new ArrayList<TupleEntry>();
   final TupleEntryCollector collector = new TupleEntryCollector() {
 
     @Override
     public void add(Tuple tuple) {
-      collected.add(new TupleEntry(fields, tuple));
+      collected.add(new TupleEntry(argumentFields, tuple));
     }
 
     @Override
@@ -46,8 +47,9 @@ abstract class AbstractOperationCallStub<C> implements OperationCall<C> {
     }
   };
 
-  AbstractOperationCallStub(Fields fields) {
-    this.fields = fields;
+  AbstractOperationCallStub(Fields argumentFields, Fields declaredFields) {
+    this.argumentFields = argumentFields;
+    this.declaredFields = declaredFields;
   }
 
   @Override
@@ -62,11 +64,11 @@ abstract class AbstractOperationCallStub<C> implements OperationCall<C> {
 
   @Override
   public Fields getArgumentFields() {
-    return fields;
+    return argumentFields;
   }
 
   public Fields getDeclaredFields() {
-    return fields;
+    return declaredFields;
   }
 
   public TupleEntryCollector getOutputCollector() {
@@ -82,7 +84,7 @@ abstract class AbstractOperationCallStub<C> implements OperationCall<C> {
     for (TupleEntry entry : collected) {
       output.add(entry.getTupleCopy());
     }
-    return new Data(fields, Collections.unmodifiableList(output));
+    return new Data(declaredFields, Collections.unmodifiableList(output));
   }
 
 }

--- a/src/main/java/com/hotels/plunger/AggregatorCallStub.java
+++ b/src/main/java/com/hotels/plunger/AggregatorCallStub.java
@@ -44,8 +44,8 @@ public final class AggregatorCallStub<C> extends AbstractOperationCallStub<C> im
   private TupleEntry currentArguments;
   private TupleEntry currentGroup;
 
-  private AggregatorCallStub(Fields fields, Map<TupleEntry, List<TupleEntry>> map) {
-    super(fields);
+  private AggregatorCallStub(Fields argumentFields, Fields declaredFields, Map<TupleEntry, List<TupleEntry>> map) {
+    super(argumentFields, declaredFields);
     groupsIterator = map.entrySet().iterator();
   }
 
@@ -147,7 +147,7 @@ public final class AggregatorCallStub<C> extends AbstractOperationCallStub<C> im
     public AggregatorCallStub<C> build() {
       Fields fields = outputFields != null ? outputFields : nonGroupFields;
       flush();
-      return new AggregatorCallStub<C>(fields, map);
+      return new AggregatorCallStub<C>(nonGroupFields, fields, map);
     }
 
     private void flush() {

--- a/src/main/java/com/hotels/plunger/BufferCallStub.java
+++ b/src/main/java/com/hotels/plunger/BufferCallStub.java
@@ -44,8 +44,8 @@ public final class BufferCallStub<C> extends AbstractOperationCallStub<C> implem
   private TupleEntry currentGroup;
   private boolean retainValues;
 
-  private BufferCallStub(Fields fields, Map<TupleEntry, List<TupleEntry>> map) {
-    super(fields);
+  private BufferCallStub(Fields argumentFields, Fields declaredFields, Map<TupleEntry, List<TupleEntry>> map) {
+    super(argumentFields, declaredFields);
     groupsIterator = map.entrySet().iterator();
   }
 
@@ -163,7 +163,7 @@ public final class BufferCallStub<C> extends AbstractOperationCallStub<C> implem
         fields = nonGroupFields;
       }
       flush();
-      return new BufferCallStub<C>(fields, map);
+      return new BufferCallStub<C>(nonGroupFields, fields, map);
     }
 
   }

--- a/src/main/java/com/hotels/plunger/FunctionCallStub.java
+++ b/src/main/java/com/hotels/plunger/FunctionCallStub.java
@@ -40,8 +40,8 @@ public final class FunctionCallStub<C> extends AbstractOperationCallStub<C> impl
 
   private TupleEntry currentArguments;
 
-  private FunctionCallStub(Fields fields, Iterable<TupleEntry> arguments) {
-    super(fields);
+  private FunctionCallStub(Fields argumentFields, Fields declaredFields, Iterable<TupleEntry> arguments) {
+    super(argumentFields, declaredFields);
     this.arguments = arguments.iterator();
   }
 
@@ -116,7 +116,7 @@ public final class FunctionCallStub<C> extends AbstractOperationCallStub<C> impl
 
     public FunctionCallStub<C> build() {
       Fields newFields = outputFields != null ? outputFields : fields;
-      return new FunctionCallStub<C>(newFields, tuples);
+      return new FunctionCallStub<C>(fields, newFields, tuples);
     }
 
   }

--- a/src/test/java/com/hotels/plunger/AggregatorCallStubTest.java
+++ b/src/test/java/com/hotels/plunger/AggregatorCallStubTest.java
@@ -27,8 +27,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.hotels.plunger.AggregatorCallStub;
-
 import cascading.flow.FlowProcess;
 import cascading.operation.aggregator.First;
 import cascading.operation.aggregator.MaxValue;
@@ -76,6 +74,14 @@ public class AggregatorCallStubTest {
   public void fields() {
     stub = new AggregatorCallStub.Builder<String>(GROUP_FIELDS, NON_GROUP_FIELDS).build();
     assertThat(stub.getArgumentFields(), is(NON_GROUP_FIELDS));
+    assertThat(stub.getDeclaredFields(), is(NON_GROUP_FIELDS));
+  }
+
+  @Test
+  public void argumentsFieldsIgnoreOutputFields() {
+    stub = new AggregatorCallStub.Builder<String>(GROUP_FIELDS, NON_GROUP_FIELDS).outputFields(OUTPUT_FIELDS).build();
+    assertThat(stub.getArgumentFields(), is(NON_GROUP_FIELDS));
+    assertThat(stub.getDeclaredFields(), is(OUTPUT_FIELDS));
   }
 
   @Test

--- a/src/test/java/com/hotels/plunger/BufferCallStubTest.java
+++ b/src/test/java/com/hotels/plunger/BufferCallStubTest.java
@@ -27,8 +27,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.hotels.plunger.BufferCallStub;
-
 import cascading.flow.FlowProcess;
 import cascading.operation.BaseOperation;
 import cascading.operation.Buffer;
@@ -86,6 +84,22 @@ public class BufferCallStubTest {
     assertThat(actual.get(1), tupleEntry(OUTPUT, 2));
     assertThat(actual.get(2), tupleEntry(OUTPUT, 1));
     assertThat(actual.get(3), tupleEntry(OUTPUT, 2));
+  }
+
+  @Test
+  public void fields() {
+    BufferCallStub<Void> stub = new BufferCallStub.Builder<Void>(GROUP_FIELDS, NON_GROUP_FIELDS).build();
+    assertThat(stub.getArgumentFields(), is(NON_GROUP_FIELDS));
+    assertThat(stub.getDeclaredFields(), is(NON_GROUP_FIELDS));
+  }
+
+  @Test
+  public void argumentsFieldsIgnoreOutputFields() {
+    BufferCallStub<Void> stub = new BufferCallStub.Builder<Void>(GROUP_FIELDS, NON_GROUP_FIELDS)
+        .outputFields(OUTPUT)
+        .build();
+    assertThat(stub.getArgumentFields(), is(NON_GROUP_FIELDS));
+    assertThat(stub.getDeclaredFields(), is(OUTPUT));
   }
 
   static class CountBuffer extends BaseOperation<Void> implements Buffer<Void> {

--- a/src/test/java/com/hotels/plunger/FunctionCallStubTest.java
+++ b/src/test/java/com/hotels/plunger/FunctionCallStubTest.java
@@ -25,8 +25,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.hotels.plunger.FunctionCallStub;
-
 import cascading.flow.FlowProcess;
 import cascading.operation.Identity;
 import cascading.operation.Insert;
@@ -57,6 +55,14 @@ public class FunctionCallStubTest {
   public void fields() {
     stub = new FunctionCallStub.Builder<String>(FIELDS).build();
     assertThat(stub.getArgumentFields(), is(FIELDS));
+    assertThat(stub.getDeclaredFields(), is(FIELDS));
+  }
+
+  @Test
+  public void argumentsFieldsIgnoreOutputFields() {
+    stub = new FunctionCallStub.Builder<String>(FIELDS).outputFields(OUTPUT).build();
+    assertThat(stub.getArgumentFields(), is(FIELDS));
+    assertThat(stub.getDeclaredFields(), is(OUTPUT));
   }
 
   @Test
@@ -125,5 +131,4 @@ public class FunctionCallStubTest {
     assertThat(actual.get(0), tupleEntry(OUTPUT, 1));
     assertThat(actual.get(1), tupleEntry(OUTPUT, 1));
   }
-
 }


### PR DESCRIPTION
changed OperationCallStubs to correctly distinguish between argumentFields (input) and declaredFields (output)
