### PR TITLE
make TupleListTap constructor public

### DIFF
--- a/src/main/java/com/hotels/plunger/TupleListTap.java
+++ b/src/main/java/com/hotels/plunger/TupleListTap.java
@@ -43,7 +43,7 @@ public class TupleListTap extends Tap<Properties, Iterator<Tuple>, List<Tuple>> 
   /**
    * Constructs a tap that can provided the declared {@link Tuple Tuples} into a {@link Pipe}.
    */
-  TupleListTap(Fields fields, Iterable<Tuple> input) {
+  public TupleListTap(Fields fields, Iterable<Tuple> input) {
     super(new TupleScheme(fields));
     this.input = input.iterator();
     id = getClass().getSimpleName() + ":" + UUID.randomUUID().toString();


### PR DESCRIPTION
This change allows a TupleListTap to be used with cascading 3.0.

The following code fails when using `3.0.0-wip-121`:

````java
    Fields revenueFields = Fields.join(new Fields("revenue", Double.TYPE), new Fields("currency", String.class));
    TupleListTap revenue = new DataBuilder(revenueFields)
        .addTuple(12.0d, "USD")
        .addTuple(10.0d, "GBP")
        .addTuple(11.99d, "EUR")
        .addTuple(4.0d, "EUR").toTap();
````

We get the following error:

````
java.lang.NoSuchMethodError: cascading.tuple.Tuples.coerce(Lcascading/tuple/Tuple;[Ljava/lang/Class;)Lcascading/tuple/Tuple;
	at com.hotels.plunger.DataBuilder.flushTupleEntry(DataBuilder.java:185)
	at com.hotels.plunger.DataBuilder.newTuple(DataBuilder.java:69)
	at com.hotels.plunger.DataBuilder.addTuple(DataBuilder.java:76)
````

If the TupleListTap constructor is public, the following is equivalent and works:

````java
    TupleListTap revenue = new TupleListTap(revenueFields, ImmutableList.<Tuple>builder()
        .add(new Tuple(12.0d, "USD"))
        .add(new Tuple(10.0d, "GBP"))
        .add(new Tuple(11.99d, "EUR"))
        .build());
```` 
